### PR TITLE
Actually use .post on MD_S8ListJoin

### DIFF
--- a/source/md.c
+++ b/source/md.c
@@ -1162,8 +1162,8 @@ MD_S8ListJoin(MD_Arena *arena, MD_String8List list, MD_StringJoin *join_ptr)
             ptr += join.mid.size;
         }
     }
-    MD_MemoryCopy(ptr, join.pre.str, join.pre.size);
-    ptr += join.pre.size;
+    MD_MemoryCopy(ptr, join.post.str, join.post.size);
+    ptr += join.post.size;
     
     return(result);
 }


### PR DESCRIPTION
It was using `.pre` again.