### PR TITLE
Fix new chunk link in MD_ArenaDefaultPush

### DIFF
--- a/source/md.c
+++ b/source/md.c
@@ -545,6 +545,7 @@ MD_ArenaDefaultPush(MD_ArenaDefault *arena, MD_u64 size)
                 current = new_arena;
                 pos_aligned = current->pos;
                 new_pos = pos_aligned + size;
+                arena->current = current;
             }
         }
         


### PR DESCRIPTION
Small fix to `MD_ArenaDefaultPush`. There's a local copy of the arena's current pointer that isn't written back after it's updated when a new chunk is allocated. I think currently the back pointer chain is broken and is preventing newly allocated blocks from being freed in ArenaRelease.