### PR TITLE
Fix MD_S8ChopWhitespace underflow and infinite loop

### DIFF
--- a/source/md.c
+++ b/source/md.c
@@ -1633,11 +1633,11 @@ MD_S8SkipWhitespace(MD_String8 string)
 MD_FUNCTION MD_String8
 MD_S8ChopWhitespace(MD_String8 string)
 {
-    for(MD_u64 i = string.size-1; i < string.size; i -= 1)
+    for(MD_u64 i = 1; i <= string.size; i += 1)
     {
-        if(!MD_CharIsSpace(string.str[i]))
+        if(!MD_CharIsSpace(string.str[string.size-i]))
         {
-            string = MD_S8Prefix(string, i+1);
+            string = MD_S8Prefix(string, string.size-i+1);
             break;
         }
     }


### PR DESCRIPTION
`MD_S8ChopWhitespace` has two obvious bugs:

1) `MD_u64 i = string.size-1` can underflow when string.size is 0.
2) `i < string.size` is the wrong condition to check for a loop that starts at the end of the string.

Theoretically, this PR fixes both issues, but haven't tested this code at all, so you may want to test it on your side or just fix the loop yourself in whatever way you see fit. :)

The code I wrote is a bit contrived, but I looped forward instead of backward to avoid the decrement at zero problem that would've required us to replace MD_u64 with a signed type. This preserves the upper half of the unsigned range in the extraordinarly unlikely case that someone has a string that large (maybe's it's a virtual string? lol).