### PR TITLE
update MD_ArenaDefault current pointer in MD_ArenaDefaultPush after allocating new arena

### DIFF
--- a/source/md.c
+++ b/source/md.c
@@ -543,6 +543,7 @@ MD_ArenaDefaultPush(MD_ArenaDefault *arena, MD_u64 size)
                 new_arena->base_pos = current->base_pos + current->cap;
                 new_arena->prev = current;
                 current = new_arena;
+                arena->current = current;
                 pos_aligned = current->pos;
                 new_pos = pos_aligned + size;
             }


### PR DESCRIPTION
I'm not familiar with this codebase, I was just looking at the arena implementation, so excuse me if this is not correct, but I believe it's intended that the "current" pointer is updated after adding a new arena to the linked list, which would be congruent with MD_ArenaDefaultPopTo behaviour.