### PR TITLE
Fix parsing numeric literal zero

### DIFF
--- a/source/md.c
+++ b/source/md.c
@@ -1701,7 +1701,7 @@ MD_StringIsCStyleInt(MD_String8 string)
     if (ptr < opl)
     {
         MD_u8 c0 = *ptr;
-        if (c0 == '0')
+        if (c0 == '0' && string.size > 1)
         {
             ptr += 1;
             radix = 8;
@@ -1769,7 +1769,7 @@ MD_CStyleIntFromString(MD_String8 string)
     if (p < string.size)
     {
         MD_u8 c0 = string.str[p];
-        if (c0 == '0')
+        if (c0 == '0' && string.size > 1)
         {
             p += 1;
             radix = 8;


### PR DESCRIPTION
Neither `MD_StringIsCStyleInt` nor `MD_CStyleIntFromString` handle the literal number `0` correctly. They think that a `0` is an octal number and try to parse it with radix 8.

For `MD_StringIsCStyleInt` this incorrectly returns false.
For `MD_CStyleIntFromString` it coincidentally returns a zero, despite the code not flowing as expected.